### PR TITLE
fix: use devel image to have cuda compiler, cudnn8 for tf and optimize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip wget \
+    && apt-get install -y --no-install-recommends python3 python3-pip wget libglib2.0-0 libsm6 libxrender1 libxext6 libgl1 \
     && ln -sf python3 /usr/bin/python \
     && ln -sf pip3 /usr/bin/pip \
     && pip install --upgrade pip \


### PR DESCRIPTION
to properly install cuda compiler, it's better to use devel cuda image.
Also tf needs cudnn8 although we're using cuda 11.6. Based on https://github.com/tensorflow/tensorflow/issues/45200
We also add opengl dependencies
Finally some optimizations for the dockerfile
