### PR TITLE
When running on windows, if you don't set the delete=false flag...

### DIFF
--- a/executors/glid3/executor.py
+++ b/executors/glid3/executor.py
@@ -18,7 +18,7 @@ class GLID3Diffusion(Executor):
 
     async def run_glid3(self, d: Document, text: str, skip_rate: float, num_images: int):
         with tempfile.NamedTemporaryFile(
-                suffix='.png',
+                suffix='.png',delete=False
         ) as f_in:
             self.logger.info(f'diffusion [{text}] ...')
             from dalle_flow_glid3.cli_parser import parser


### PR DESCRIPTION
 it errors on diffusion