### PR TITLE
fix: index url for installing jax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     git clone --depth=1 https://github.com/JingyunLiang/SwinIR.git  && \
     git clone --depth=1 https://github.com/CompVis/latent-diffusion.git && \
     git clone --depth=1 https://github.com/hanxiao/glid-3-xl.git && \
-    pip install "jax==0.3.13" && \
-    pip install "jaxlib[cuda11_cudnn82]==0.3.10" -f https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    pip install "jax==0.3.13" "jaxlib[cuda11_cudnn82]==0.3.10" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
     pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113 && \
     cd latent-diffusion && pip install --timeout=1000 -e . && cd - && \
     cd glid-3-xl && pip install --timeout=1000 -e . && cd - && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jina>=3.4.5
 clip_client>=0.4.0
 docarray>=0.13.5
 # dalle-mini
-jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 flax
 git+https://github.com/openai/CLIP.git
 git+https://github.com/huggingface/transformers.git


### PR DESCRIPTION
The index has recently changed URL as described here: https://github.com/google/jax/issues/11142