### PR TITLE
Fix jax version 0.3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ cd -
 ```bash
 cd dalle-flow
 pip install -r requirements.txt
-pip install jax==0.3.13
+pip install jax==0.3.14
 ```
 
 ### Start the server


### PR DESCRIPTION
```RuntimeError: jaxlib version 0.3.14 is newer than and incompatible with jax version 0.3.13. Please update your jax and/or jaxlib packages.```