### PR TITLE
Add dalle2-laion to inference engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,14 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     git clone --depth=1 https://github.com/JingyunLiang/SwinIR.git  && \
     git clone --depth=1 https://github.com/CompVis/latent-diffusion.git && \
     git clone --depth=1 https://github.com/hanxiao/glid-3-xl.git && \
+    git clone --depth=1 https://github.com/LAION-AI/dalle2-laion && \
     pip install jax[cuda11_cudnn82]==0.3.13 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
     pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113 && \
+    pip install dalle2-pytorch==1.0.3 && \
     cd latent-diffusion && pip install --timeout=1000 -e . && cd - && \
     cd glid-3-xl && pip install --timeout=1000 -e . && cd - && \
     cd dalle-flow && pip install --timeout=1000 --compile -r requirements.txt && cd - && \
+    cd dalle2-laion && pip install --timeout=1000 -e . && cd - && \
     cd glid-3-xl && \
     wget -q https://dall-3.com/models/glid-3-xl/bert.pt &&  \
     wget -q https://dall-3.com/models/glid-3-xl/kl-f8.pt &&  \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 
 
-DALL·E Flow is an interactive workflow for generating high-definition images from text prompt. First, it leverages [DALL·E-Mega](https://github.com/borisdayma/dalle-mini) to generate image candidates, and then calls [CLIP-as-service](https://github.com/jina-ai/clip-as-service) to rank the candidates w.r.t. the prompt. The preferred candidate is fed to [GLID-3 XL](https://github.com/Jack000/glid-3-xl) for diffusion, which often enriches the texture and background. Finally, the candidate is upscaled to 1024x1024 via [SwinIR](https://github.com/JingyunLiang/SwinIR).
+DALL·E Flow is an interactive workflow for generating high-definition images from text prompt. First, it leverages [DALL·E-Mega](https://github.com/borisdayma/dalle-mini) and [DALL·E2-LAION](https://github.com/LAION-AI/dalle2-laion) to generate image candidates, and then calls [CLIP-as-service](https://github.com/jina-ai/clip-as-service) to rank the candidates w.r.t. the prompt. The preferred candidate is fed to [GLID-3 XL](https://github.com/Jack000/glid-3-xl) for diffusion, which often enriches the texture and background. Finally, the candidate is upscaled to 1024x1024 via [SwinIR](https://github.com/JingyunLiang/SwinIR).
 
 DALL·E Flow is built with [Jina](https://github.com/jina-ai/jina) in a client-server architecture, which gives it high scalability, non-blocking streaming, and a modern Pythonic interface. Client can interact with the server via gRPC/Websocket/HTTP with TLS.
 
@@ -29,6 +29,7 @@ DALL·E Flow is in client-server architecture.
 
 ## Updates
 
+- 🌟 **2022/7/29** Added dalle2-laion to inference engine
 - ⚠️ **2022/7/6** Demo server migration to AWS EKS for better availability and robustness, **server URL is now changing to `grpcs://dalle-flow.dev.jina.ai`**. All connections are now with TLS encryption, [please _reopen_ the notebook in Google Colab](https://colab.research.google.com/github/jina-ai/dalle-flow/blob/main/client.ipynb).
 - ⚠️ **2022/6/25** Unexpected downtime between 6/25 0:00 - 12:00 CET due to out of GPU quotas. The new server now has 2 GPUs, add healthcheck in client notebook.
 - **2022/6/3** Reduce default number of images to 2 per pathway, 4 for diffusion.
@@ -244,6 +245,7 @@ git clone https://github.com/jina-ai/dalle-flow.git
 git clone https://github.com/JingyunLiang/SwinIR.git
 git clone https://github.com/CompVis/latent-diffusion.git
 git clone https://github.com/hanxiao/glid-3-xl.git
+git clone https://github.com/LAION-AI/dalle2-laion
 ```
 
 You should have the following folder structure:
@@ -262,6 +264,13 @@ dalle/
 ```bash
 cd latent-diffusion && pip install -e . && cd -
 cd glid-3-xl && pip install -e . && cd -
+cd dalle2-laion && pip install -e . && cd -
+```
+
+Install DALLE2-pytorch:
+
+```bash
+pip install dalle2-pytorch==1.0.3
 ```
 
 There are couple models we need to download for GLID-3-XL:

--- a/executors/dalle2/executor.py
+++ b/executors/dalle2/executor.py
@@ -1,0 +1,57 @@
+import os
+import time
+from io import BytesIO
+from typing import Dict
+
+from dalle2_laion import DalleModelManager, ModelLoadConfig, utils
+from dalle2_laion.scripts import BasicInference
+
+from jina import Executor, requests, DocumentArray, Document
+
+# Defaults
+#
+# prior_batch_size: int = 100,
+# decoder_batch_size: int = 10,
+# prior_num_samples_per_batch: int = 2
+
+DECODER_BATCH_SIZE = 36
+PRIOR_BATCH_SIZE = 256
+PRIOR_NUM_SAMPLES_PER_BATCH = 4
+MODEL_PATH = '../dalle2-laion/configs/upsampler.example.json'
+
+dreamer: BasicInference = BasicInference.create(MODEL_PATH, verbose=True)
+
+class Dalle2Generator(Executor):
+    @requests(on='/')
+    def generate(self, docs: DocumentArray, parameters: Dict, **kwargs):
+        # can be of course larger but to save time and reduce the queue when serving public
+        num_images = max(1, min(9, int(parameters.get('num_images', 1))))
+        request_time = time.time()
+        for d in docs:
+            self.logger.info(f'dalle2 {num_images} [{d.text}]...')
+            output_map = dreamer.run([d.text],
+                prior_batch_size=PRIOR_BATCH_SIZE,
+                prior_num_samples_per_batch=PRIOR_NUM_SAMPLES_PER_BATCH,
+                prior_sample_count=num_images,
+                decoder_batch_size=DECODER_BATCH_SIZE,
+            )
+
+            for text in output_map:
+                for embedding_index in output_map[text]:
+                    for img in output_map[text][embedding_index]:
+                        buffered = BytesIO()
+                        img.save(buffered, format='PNG')
+                        _d = Document(
+                            blob=buffered.getvalue(),
+                            mime_type='image/png',
+                            tags={
+                                'text': d.text,
+                                'generator': 'DALLE2-1m',
+                                'request_time': request_time,
+                                'created_time': time.time(),
+                            },
+                        ).convert_blob_to_datauri()
+                        _d.text = d.text
+                        d.matches.append(_d)
+
+            self.logger.info(f'done dalle2 with [{d.text}]')

--- a/flow.yml
+++ b/flow.yml
@@ -13,6 +13,16 @@ executors:
       CUDA_VISIBLE_DEVICES: 0  # change this if you have multiple GPU
       XLA_PYTHON_CLIENT_ALLOCATOR: platform  # https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
     replicas: 1  # change this if you have larger VRAM
+  - name: dalle2
+    uses: Dalle2Generator
+    timeout_ready: -1 # Give time to download
+    py_modules:
+      - executors/dalle2/executor.py
+    env:
+      CUDA_VISIBLE_DEVICES: 0  # change this if you have multiple GPU
+      XLA_PYTHON_CLIENT_ALLOCATOR: platform  # https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
+    replicas: 1  # change this if you have larger VRAM
+    needs: [gateway]
   - name: diffusion
     uses: GLID3Diffusion
     uses_with:
@@ -31,7 +41,7 @@ executors:
       clip_server: grpcs://demo-cas.jina.ai:2096
     py_modules:
       - executors/rerank/executor.py
-    needs: [dalle, diffusion]
+    needs: [dalle, dalle2, diffusion]
   - name: upscaler
     uses: SwinIRUpscaler
     py_modules:


### PR DESCRIPTION
This adds the open source version of DALLE2 trained on LAION to the
inference pipeline. It uses the 1B parameter model of DALLE2 currently
being trained on LAION images. It requires an addition 11 GB of VRAM
to run with the other pipelines.