### PR TITLE
perf: generate images only on request to '/'

### DIFF
--- a/executors/dalle/executor/dalle.py
+++ b/executors/dalle/executor/dalle.py
@@ -8,7 +8,7 @@ from . import dm_helper
 
 
 class DalleGenerator(Executor):
-    @requests
+    @requests(on='/')
     def generate(self, docs: DocumentArray, parameters: Dict, **kwargs):
 
         # can be of course larger but to save time and reduce the queue when serving public

--- a/executors/glid3/executor.py
+++ b/executors/glid3/executor.py
@@ -68,7 +68,7 @@ class GLID3Diffusion(Executor):
 
             self.logger.info(f'done with [{text}]!')
 
-    @requests
+    @requests(on='/')
     def diffusion(self, docs: DocumentArray, parameters: Dict, **kwargs):
         skip_rate = float(parameters.get('skip_rate', 0.5))
         num_images = max(1, min(9, int(parameters.get('num_images', 1))))


### PR DESCRIPTION
putting back `on='/'` for performance improvement.