### PR TITLE
Download the glid3xl latent diffusion weights at runtime, only if required, so that the image size will fit on docker repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip wget libglib2.0-0 libsm6 libxrender1 libxext6 libgl1 \
+    && apt-get install -y --no-install-recommends sudo python3 python3-pip wget libglib2.0-0 libsm6 libxrender1 libxext6 libgl1 \
     && ln -sf python3 /usr/bin/python \
     && ln -sf pip3 /usr/bin/pip \
     && pip install --upgrade pip \
@@ -39,9 +39,6 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     cd glid-3-xl && pip install --timeout=1000 -e . && cd - && \
     cd dalle-flow && pip install --timeout=1000 --compile -r requirements.txt && cd - && \
     cd glid-3-xl && \
-    wget -q https://dall-3.com/models/glid-3-xl/bert.pt &&  \
-    wget -q https://dall-3.com/models/glid-3-xl/kl-f8.pt &&  \
-    wget -q https://dall-3.com/models/glid-3-xl/finetune.pt && cd - && \
     # now remove apt packages
     if [ -n "${APT_PACKAGES}" ]; then apt-get remove -y --auto-remove ${APT_PACKAGES} && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*; fi
 
@@ -54,10 +51,12 @@ ARG GROUP_ID=1000
 ARG USER_NAME=dalle
 ARG GROUP_NAME=dalle
 
-RUN groupadd -g ${GROUP_ID} ${USER_NAME} &&\
-    useradd -l -u ${USER_ID} -g ${USER_NAME} ${GROUP_NAME} &&\
-    mkdir /home/${USER_NAME} &&\
-    chown ${USER_NAME}:${GROUP_NAME} /home/${USER_NAME} &&\
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
+    useradd -l -u ${USER_ID} -g ${USER_NAME} ${GROUP_NAME} | chpasswd && \
+    adduser ${USER_NAME} sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    mkdir /home/${USER_NAME} && \
+    chown ${USER_NAME}:${GROUP_NAME} /home/${USER_NAME} && \
     chown -R ${USER_NAME}:${GROUP_NAME} /dalle/
 
 USER ${USER_NAME}

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,22 @@
 #!/bin/sh
+if test ${DISABLE_GLID3XL}; then
+  echo "Latent diffusion checkpoints will not be downloaded because DISABLE_GLID3XL flag is on"
+else
+  if test -e /home/dalle/.cache/bert.pt -a -e /home/dalle/.cache/kl-f8.pt -a -e /home/dalle/.cache/finetune.pt; then
+    echo "Latent diffusion checkpoints for glid3xl exist, continuing"
+  else 
+    echo "Latent diffusion checkpoints for glid3xl not exist, downloading"
+    sudo apt update
+    sudo apt install -y wget
+    wget https://dall-3.com/models/glid-3-xl/bert.pt -O /home/dalle/.cache/bert.pt
+    wget https://dall-3.com/models/glid-3-xl/kl-f8.pt -O /home/dalle/.cache/kl-f8.pt
+    wget https://dall-3.com/models/glid-3-xl/finetune.pt -O /home/dalle/.cache/finetune.pt
+  fi
+
+  ln -s /home/dalle/.cache/bert.pt /dalle/glid-3-xl/bert.pt
+  ln -s /home/dalle/.cache/kl-f8.pt /dalle/glid-3-xl/kl-f8.pt
+  ln -s /home/dalle/.cache/finetune.pt /dalle/glid-3-xl/finetune.pt
+fi
+
 python3 flow_parser.py
 jina flow --uses flow.tmp.yml


### PR DESCRIPTION
After this update, the size of the image is much less than 20 GB.

```
REPOSITORY    TAG                               IMAGE ID       CREATED          SIZE
dalle-test    latest                            68fe8693a0e4   14 minutes ago   13.3GB
```