### PR TITLE
Add interpolation endpoint to Stable Diffusion executor

### DIFF
--- a/executors/stable/executor.py
+++ b/executors/stable/executor.py
@@ -1,10 +1,11 @@
 import PIL
-import k_diffusion as K
-import numpy as np
 import os
 import shutil
 import time
 import torch
+
+import k_diffusion as K
+import numpy as np
 import torch.nn as nn
 
 from PIL import Image
@@ -80,8 +81,12 @@ def load_model_from_config(config, ckpt):
     return model
 
 
-def load_img(path):
-    image = Image.open(path).convert("RGB")
+def load_img(path, img=None):
+    image = None
+    if img is None:
+        image = Image.open(path).convert("RGB")
+    else:
+        image = img
     w, h = image.size
     w, h = map(lambda x: x - x % 32, (w, h))  # resize to integer multiple of 32
     image = image.resize((w, h), resample=PIL.Image.LANCZOS)
@@ -89,6 +94,37 @@ def load_img(path):
     image = image[None].transpose(0, 3, 1, 2)
     image = torch.from_numpy(image)
     return 2.*image - 1.
+
+
+def slerp(t, v0, v1, DOT_THRESHOLD=0.9995):
+    """
+    helper function to spherically interpolate two arrays v1 v2
+
+    from @xsteenbrugge
+    """
+
+    if not isinstance(v0, np.ndarray):
+        inputs_are_torch = True
+        input_device = v0.device
+        v0 = v0.cpu().numpy()
+        v1 = v1.cpu().numpy()
+
+    dot = np.sum(v0 * v1 / (np.linalg.norm(v0) * np.linalg.norm(v1)))
+    if np.abs(dot) > DOT_THRESHOLD:
+        v2 = (1 - t) * v0 + t * v1
+    else:
+        theta_0 = np.arccos(dot)
+        sin_theta_0 = np.sin(theta_0)
+        theta_t = theta_0 * t
+        sin_theta_t = np.sin(theta_t)
+        s0 = np.sin(theta_0 - theta_t) / sin_theta_0
+        s1 = sin_theta_t / sin_theta_0
+        v2 = s0 * v0 + s1 * v1
+
+    if inputs_are_torch:
+        v2 = torch.from_numpy(v2).to(input_device)
+
+    return v2
 
 
 class StableDiffusionGenerator(Executor):
@@ -138,6 +174,63 @@ class StableDiffusionGenerator(Executor):
             ddim_num_steps=self.opt.ddim_steps, ddim_eta=self.opt.ddim_eta,
                 verbose=False)
 
+    def _sample_text(self, prompts, n_samples, batch_size, opt, sampler, steps,
+        start_code):
+        '''
+        Create image(s) from text.
+        '''
+        uc = None
+        if opt.scale != 1.0:
+            uc = self.model.get_learned_conditioning(batch_size * [""])
+        if isinstance(prompts, tuple):
+            prompts = list(prompts)
+        c = self.model.get_learned_conditioning(prompts)
+        shape = [opt.C, opt.height // opt.f, opt.width // opt.f]
+        torch.cuda.empty_cache()
+
+        samples = None
+        if sampler == 'ddim':
+            samples, _ = self.sampler.sample(
+                S=steps,
+                conditioning=c,
+                batch_size=n_samples,
+                shape=shape,
+                verbose=False,
+                unconditional_guidance_scale=opt.scale,
+                unconditional_conditioning=uc,
+                eta=opt.ddim_eta,
+                x_T=start_code)
+        if sampler in K_DIFF_SAMPLERS:
+            # k_lms is the fallthrough
+            sampling_fn = K.sampling.sample_lms
+            if sampler == 'dpm2':
+                sampling_fn = K.sampling.sample_dpm_2
+            if sampler == 'dpm2_ancestral':
+                sampling_fn = K.sampling.sample_dpm_2_ancestral
+            if sampler == 'heun':
+                sampling_fn = K.sampling.sample_heun
+            if sampler == 'euler':
+                sampling_fn = K.sampling.sample_euler
+            if sampler == 'euler_ancestral':
+                sampling_fn = K.sampling.sample_euler_ancestral
+
+            sigmas = self.model_k_wrapped.get_sigmas(opt.ddim_steps)
+            x = torch.randn([n_samples, *shape], device=self.device) * sigmas[0] # for GPU draw
+            extra_args = {
+                'cond': c,
+                'uncond': uc,
+                'cond_scale': opt.scale,
+            }
+            samples = sampling_fn(
+                self.model_k_config,
+                x,
+                sigmas,
+                extra_args=extra_args)
+
+        x_samples_ddim = self.model.decode_first_stage(samples)
+        x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
+        return x_samples_ddim
+
     @requests(on='/')
     def txt2img(self, docs: DocumentArray, parameters: Dict, **kwargs):
         request_time = time.time()
@@ -180,57 +273,8 @@ class StableDiffusionGenerator(Executor):
                         self.logger.info(f'stable diffusion start {num_images} images, prompt "{prompt}"...')
                         for n in trange(n_iter, desc="Sampling"):
                             for prompts in tqdm(data, desc="data"):
-                                uc = None
-                                if opt.scale != 1.0:
-                                    uc = self.model.get_learned_conditioning(batch_size * [""])
-                                if isinstance(prompts, tuple):
-                                    prompts = list(prompts)
-                                c = self.model.get_learned_conditioning(prompts)
-                                shape = [opt.C, opt.height // opt.f, opt.width // opt.f]
-                                torch.cuda.empty_cache()
-
-                                samples = None
-                                if sampler == 'ddim':
-                                    samples, _ = self.sampler.sample(
-                                        S=steps,
-                                        conditioning=c,
-                                        batch_size=n_samples,
-                                        shape=shape,
-                                        verbose=False,
-                                        unconditional_guidance_scale=opt.scale,
-                                        unconditional_conditioning=uc,
-                                        eta=opt.ddim_eta,
-                                        x_T=start_code)
-                                if sampler in K_DIFF_SAMPLERS:
-                                    # k_lms is the fallthrough
-                                    sampling_fn = K.sampling.sample_lms
-                                    if sampler == 'dpm2':
-                                        sampling_fn = K.sampling.sample_dpm_2
-                                    if sampler == 'dpm2_ancestral':
-                                        sampling_fn = K.sampling.sample_dpm_2_ancestral
-                                    if sampler == 'heun':
-                                        sampling_fn = K.sampling.sample_heun
-                                    if sampler == 'euler':
-                                        sampling_fn = K.sampling.sample_euler
-                                    if sampler == 'euler_ancestral':
-                                        sampling_fn = K.sampling.sample_euler_ancestral
-
-                                    sigmas = self.model_k_wrapped.get_sigmas(opt.ddim_steps)
-                                    x = torch.randn([n_samples, *shape], device=self.device) * sigmas[0] # for GPU draw
-                                    extra_args = {
-                                        'cond': c,
-                                        'uncond': uc,
-                                        'cond_scale': opt.scale,
-                                    }
-                                    samples = sampling_fn(
-                                        self.model_k_config,
-                                        x,
-                                        sigmas,
-                                        extra_args=extra_args)
-
-                                x_samples_ddim = self.model.decode_first_stage(samples)
-                                x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
-
+                                x_samples_ddim = self._sample_text(prompts, n_samples,
+                                    batch_size, opt, sampler, steps, start_code)
                                 for x_sample in x_samples_ddim:
                                     x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
                                     img = Image.fromarray(x_sample.astype(np.uint8))
@@ -278,7 +322,7 @@ class StableDiffusionGenerator(Executor):
             n_samples = num_images
         if num_images // n_samples > n_iter:
             n_iter = num_images // n_samples
-        
+
         seed_everything(seed)
 
         assert 0. <= strength <= 1., 'can only work with strength in [0.0, 1.0]'
@@ -392,3 +436,142 @@ class StableDiffusionGenerator(Executor):
                                     d.matches.append(_d)
 
                             shutil.rmtree(input_path, ignore_errors=True)
+
+    @requests(on='/stableinterpolate')
+    def stableinterpolate(self, docs: DocumentArray, parameters: Dict, **kwargs):
+        '''
+        Create a series of images that are interpolations between two prompts.
+        '''
+        request_time = time.time()
+
+        num_images = max(1, min(16, int(parameters.get('num_images', 1))))
+        sampler = parameters.get('sampler', 'k_lms')
+        scale = parameters.get('scale', 7.5)
+        seed = int(parameters.get('seed', randint(0, 2 ** 32 - 1)))
+        strength = parameters.get('strength', 0.75)
+
+        if sampler not in VALID_SAMPLERS:
+            raise ValueError(f'sampler must be in {VALID_SAMPLERS}, got {sampler}')
+
+        opt = self.opt
+        opt.scale = scale
+
+        seed_everything(seed)
+
+        assert 0.5 <= strength <= 1., 'can only work with strength in [0.5, 1.0]'
+        t_enc = int(strength * opt.ddim_steps)
+
+        precision_scope = autocast if opt.precision == "autocast" else nullcontext
+        with torch.no_grad():
+            with precision_scope("cuda"):
+                with self.model.ema_scope():
+                    for d in docs:
+                        batch_size = 1
+                        prompt = d.text
+                        assert prompt is not None
+
+                        prompts = prompt.split('|')
+                        assert len(prompts) == 2, 'can only interpolate between two prompts'
+
+                        self.logger.info(f'stable diffusion interpolate start {num_images} images, prompt "{prompt}"...')
+
+                        prompt_embedding_start = self.model.get_learned_conditioning(prompts[0].strip())
+                        prompt_embedding_end = self.model.get_learned_conditioning(prompts[1].strip())
+
+                        to_iterate = list(enumerate(np.linspace(0, 1, num_images)))
+
+                        # Interate over interpolation percentages.
+                        last_image = None
+                        x_samples = None
+                        for i, percent in to_iterate:
+                            init_image = None
+                            init_latent = None
+                            if i == 0:
+                                start_code = None
+                                if opt.fixed_code:
+                                    start_code = torch.randn([1, opt.C, opt.height // opt.f,
+                                        opt.width // opt.f], device=self.device)
+                                x_samples = self._sample_text([prompts[0]], 1,
+                                    batch_size, opt, sampler, opt.ddim_steps,
+                                    start_code)
+                            else:
+                                init_image = load_img('', img=last_image).to(self.device)
+                                init_image = repeat(init_image, '1 ... -> b ...', b=batch_size)
+                                init_latent = self.model.get_first_stage_encoding(
+                                    self.model.encode_first_stage(init_image))
+
+                                uc = None
+                                if opt.scale != 1.0:
+                                    uc = self.model.get_learned_conditioning(batch_size * [""])
+
+                                c = None
+                                if i < 1:
+                                    c = prompt_embedding_start
+                                elif i == len(to_iterate) - 1:
+                                    c = prompt_embedding_end
+                                else:
+                                    c = slerp(percent, prompt_embedding_start,
+                                        prompt_embedding_end)
+
+                                samples = None
+                                if sampler == 'ddim':
+                                    # encode (scaled latent)
+                                    z_enc = self.sampler.stochastic_encode(
+                                        init_latent, torch.tensor([t_enc]*batch_size).to(self.device))
+                                    # decode it
+                                    samples = self.sampler.decode(z_enc, c, t_enc,
+                                        unconditional_guidance_scale=opt.scale,
+                                        unconditional_conditioning=uc)
+                                if sampler in K_DIFF_SAMPLERS:
+                                    # k_lms is the fallthrough
+                                    sampling_fn = K.sampling.sample_lms
+                                    if sampler == 'dpm2':
+                                        sampling_fn = K.sampling.sample_dpm_2
+                                    if sampler == 'dpm2_ancestral':
+                                        sampling_fn = K.sampling.sample_dpm_2_ancestral
+                                    if sampler == 'heun':
+                                        sampling_fn = K.sampling.sample_heun
+                                    if sampler == 'euler':
+                                        sampling_fn = K.sampling.sample_euler
+                                    if sampler == 'euler_ancestral':
+                                        sampling_fn = K.sampling.sample_euler_ancestral
+
+                                sigmas = self.model_k_wrapped.get_sigmas(opt.ddim_steps)
+                                x0 = init_latent
+                                noise = torch.randn_like(x0) * sigmas[opt.ddim_steps - t_enc - 1]
+                                xi = x0 + noise
+                                sigma_sched = sigmas[opt.ddim_steps - t_enc - 1:]
+                                extra_args = {
+                                    'cond': c,
+                                    'uncond': uc,
+                                    'cond_scale': opt.scale,
+                                }
+                                samples = sampling_fn(
+                                    self.model_k_config,
+                                    xi,
+                                    sigma_sched,
+                                    extra_args=extra_args,
+                                )
+
+                                x_samples = self.model.decode_first_stage(samples)
+                                x_samples = torch.clamp((x_samples + 1.0) / 2.0, min=0.0, max=1.0)
+
+                            x_sample = 255. * rearrange(x_samples[0].cpu().numpy(), 'c h w -> h w c')
+                            img = Image.fromarray(x_sample.astype(np.uint8))
+
+                            buffered = BytesIO()
+                            img.save(buffered, format='PNG')
+                            last_image = img
+                            _d = Document(
+                                blob=buffered.getvalue(),
+                                mime_type='image/png',
+                                tags={
+                                    'text': prompt,
+                                    'percent': percent,
+                                    'generator': 'stable-diffusion',
+                                    'request_time': request_time,
+                                    'created_time': time.time(),
+                                },
+                            ).convert_blob_to_datauri()
+                            _d.text = prompt
+                            d.matches.append(_d)


### PR DESCRIPTION
Adds the ability to interpolate between latent embeddings of two different prompts, with varying samplers and strengths.

Examples:

![images_tJwF1jKFE](https://user-images.githubusercontent.com/110263573/187206372-0c62eb2f-ba01-4c0c-a5c0-c2561f986410.png)
![images_ZEJBaXvaS](https://user-images.githubusercontent.com/110263573/187206382-29fdbcdf-027c-4221-8e19-597698998231.png)
