### PR TITLE
fix(stablediff): fix seed when interpolating based on conditioning alone 

### DIFF
--- a/executors/stable/executor.py
+++ b/executors/stable/executor.py
@@ -355,7 +355,7 @@ class StableDiffusionGenerator(Executor):
                         prompt,
                         batch_size,
                         sampler,
-                        seed + i,
+                        seed,
                         steps,
                         conditioning=c,
                         height=height,


### PR DESCRIPTION
Seeds determine the init noise of the image. The purpose of interpolating is to get images of the transition of latent space between two embeddings. Because seed is deterministic for image generation, when we aren't using img2img we should hold the seed constant so that images are generated with the same noise instead of different noise so they are more consistent as we traverse latent space. This is not an issue when using img2img, where noise reuse would actually corrupt the images.