### PR TITLE
Update to latest stable-inference version, fix downloading CLIP weights (Closes #124)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     git clone --depth=1 https://github.com/jina-ai/SwinIR.git  && \
     git clone --depth=1 https://github.com/CompVis/latent-diffusion.git && \
     git clone --depth=1 https://github.com/jina-ai/glid-3-xl.git && \
-    git clone --depth=1 --branch v0.0.10 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git && \
+    git clone --depth=1 --branch v0.0.12 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git && \
     cd dalle-flow && python3 -m virtualenv --python=/usr/bin/python3.10 env && . env/bin/activate && cd - && \
     pip install --upgrade cython && \
     pip install --upgrade pyyaml && \

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Running natively requires some manual steps, but it is often easier to debug.
 mkdir dalle && cd dalle
 git clone https://github.com/jina-ai/dalle-flow.git
 git clone https://github.com/jina-ai/SwinIR.git
-git clone --branch v0.0.10 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git
+git clone --branch v0.0.12 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git
 git clone https://github.com/CompVis/latent-diffusion.git
 git clone https://github.com/jina-ai/glid-3-xl.git
 ```

--- a/executors/stable/requirements.txt
+++ b/executors/stable/requirements.txt
@@ -9,5 +9,5 @@ pytorch_lightning==1.7.7
 omegaconf==2.2.3
 protobuf==3.20.0
 k-diffusion @ git+https://github.com/crowsonkb/k-diffusion.git
-stable-inference @ git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.11
+stable-inference @ git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.12
 CLIP @ git+https://github.com/openai/CLIP


### PR DESCRIPTION
There is a bug in my branch where CLIP weights do not download automatically. This updates to the latest version where they do.