### PR TITLE
Hotfix for RealESRGAN missing instance method self

### DIFF
--- a/executors/realesrgan/executor.py
+++ b/executors/realesrgan/executor.py
@@ -260,7 +260,7 @@ class RealESRGANUpscaler(Executor):
                 "model_face_fix": model_face_fix,
             }
 
-    def document_to_pil(doc):
+    def document_to_pil(self, doc):
         uri_data = urlopen(doc.uri)
         return Image.open(BytesIO(uri_data.read()))
 


### PR DESCRIPTION
When I was cleaning up the code I moved the `document_to_pil` method to the class, but neglected to add `self`. This fixes it.