### PR TITLE
Add new k-diffusion samplers to stable executor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     git clone --depth=1 https://github.com/jina-ai/SwinIR.git  && \
     git clone --depth=1 https://github.com/CompVis/latent-diffusion.git && \
     git clone --depth=1 https://github.com/jina-ai/glid-3-xl.git && \
-    git clone --depth=1 --branch v0.0.13 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git && \
+    git clone --depth=1 --branch v0.0.15 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git && \
     cd dalle-flow && python3 -m virtualenv --python=/usr/bin/python3.10 env && . env/bin/activate && cd - && \
     pip install --upgrade cython && \
     pip install --upgrade pyyaml && \

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Running natively requires some manual steps, but it is often easier to debug.
 mkdir dalle && cd dalle
 git clone https://github.com/jina-ai/dalle-flow.git
 git clone https://github.com/jina-ai/SwinIR.git
-git clone --branch v0.0.13 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git
+git clone --branch v0.0.15 https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git
 git clone https://github.com/CompVis/latent-diffusion.git
 git clone https://github.com/jina-ai/glid-3-xl.git
 git clone https://github.com/timojl/clipseg.git
@@ -339,7 +339,7 @@ source env/bin/activate && cd -
 pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
 pip install numpy tqdm pytorch_lightning einops numpy omegaconf
 pip install https://github.com/crowsonkb/k-diffusion/archive/master.zip
-pip install git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.13
+pip install git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.15
 pip install basicsr facexlib gfpgan
 pip install realesrgan
 cd latent-diffusion && pip install -e . && cd -

--- a/executors/stable/requirements.txt
+++ b/executors/stable/requirements.txt
@@ -9,5 +9,5 @@ pytorch_lightning==1.7.7
 omegaconf==2.2.3
 protobuf==3.20.0
 k-diffusion @ git+https://github.com/crowsonkb/k-diffusion.git
-stable-inference @ git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.13
+stable-inference @ git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.15
 CLIP @ git+https://github.com/openai/CLIP


### PR DESCRIPTION
This adds the newest samplers from k-diffusion into the stable executor along with the ability to choose a default noise schedule for the diffusion unet steps.

From k-diffusion: "[DPM-Solver++(2S) and (2M)](https://arxiv.org/abs/2211.01095) are implemented now too for improved quality with low numbers of steps."