### PR TITLE
Add memory efficient cross attention from xformers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN if [ -n "${APT_PACKAGES}" ]; then apt-get update && apt-get install --no-ins
     pip install https://github.com/crowsonkb/k-diffusion/archive/master.zip && \
     pip install basicsr facexlib gfpgan && \
     pip install realesrgan && \
+    pip install https://github.com/AmericanPresidentJimmyCarter/xformers-builds/raw/master/cu116/xformers-0.0.14.dev0-cp310-cp310-linux_x86_64.whl && \
     cd latent-diffusion && pip install --timeout=1000 -e . && cd - && \
     cd glid-3-xl && pip install --timeout=1000 -e . && cd - && \
     cd dalle-flow && pip install --timeout=1000 --compile -r requirements.txt && cd - && \

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can host your own server by following the instruction below.
 DALL·E Flow needs one GPU with 21GB VRAM at its peak. All services are squeezed into this one GPU, this includes (roughly)
 - DALLE ~9GB
 - GLID Diffusion ~6GB
-- Stable Diffusion ~7GB (batch_size=1 in `config.yml`, 512x512, slower) or ~14GB (batch_size=4 in `config.yml`, 512x512, slightly faster)
+- Stable Diffusion ~8GB (batch_size=4 in `config.yml`, 512x512)
 - SwinIR ~3GB
 - CLIP ViT-L/14-336px ~3GB
 
@@ -342,6 +342,7 @@ pip install https://github.com/crowsonkb/k-diffusion/archive/master.zip
 pip install git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.15
 pip install basicsr facexlib gfpgan
 pip install realesrgan
+pip install https://github.com/AmericanPresidentJimmyCarter/xformers-builds/raw/master/cu116/xformers-0.0.14.dev0-cp310-cp310-linux_x86_64.whl && \
 cd latent-diffusion && pip install -e . && cd -
 cd stable-diffusion && pip install -e . && cd -
 cd SwinIR && pip install -e . && cd -

--- a/executors/stable/config.yml
+++ b/executors/stable/config.yml
@@ -1,6 +1,6 @@
 jtype: StableDiffusionGenerator
 with:
-  batch_size: 1
+  batch_size: 4
   height: 512
   max_n_subprompts: 8
   max_resolution: 589824 # 768x768

--- a/executors/stable/requirements.txt
+++ b/executors/stable/requirements.txt
@@ -10,4 +10,5 @@ omegaconf==2.2.3
 protobuf==3.20.0
 k-diffusion @ git+https://github.com/crowsonkb/k-diffusion.git
 stable-inference @ git+https://github.com/AmericanPresidentJimmyCarter/stable-diffusion.git@v0.0.15
+https://github.com/AmericanPresidentJimmyCarter/xformers-builds/raw/master/cu116/xformers-0.0.14.dev0-cp310-cp310-linux_x86_64.whl
 CLIP @ git+https://github.com/openai/CLIP

--- a/flow_parser.py
+++ b/flow_parser.py
@@ -252,6 +252,7 @@ REALESRGAN_DICT = OrderedDict({
 })
 STABLE_YAML_DICT = OrderedDict({
     'env': {
+        'MEMORY_EFFICIENT_CROSS_ATTENTION': 1,
         'CUDA_VISIBLE_DEVICES': gpus_stable_diffusion,
         'XLA_PYTHON_CLIENT_ALLOCATOR': 'platform',
     },


### PR DESCRIPTION
This installs xformers and uses memory efficient cross attention, which can decrease Stable Diffusion inference time by 25-100% depending of the model of GPU you have.

It was implemented in my `stable-diffusion` fork a while ago, it just took me time to get around to building it for the Dockerfiles and CUDA toolkit used by this repo.

To best take advantage of the speedups, the default `batch_size` in `config.yml` has been increased to 4. Thanks for memory efficient cross attention, this results in a smaller increase in memory usage than before while increasing inference speed about 33% on my 3090.