### PR TITLE
Fix namespacing issue with the default installation of clipseg

### DIFF
--- a/executors/clipseg/executor.py
+++ b/executors/clipseg/executor.py
@@ -14,7 +14,7 @@ import cv2
 import numpy as np
 import torch
 
-from clipseg.clipseg import CLIPDensePredT
+from models.clipseg import CLIPDensePredT
 from jina import Executor, DocumentArray, Document, requests
 from torchvision import transforms
 


### PR DESCRIPTION
This fixes an issue with the docker crashing due to using the wrong namespace for clipseg.

Side note: [clipseg is now part of transformers](https://huggingface.co/docs/transformers/main/en/model_doc/clipseg)! Unfortunately it has not been released on the pypi version yet, but once that happens I will update the executor.