### PR TITLE
Fix GFPGAN/Real-ESRGAN input image color space

### DIFF
--- a/executors/realesrgan/executor.py
+++ b/executors/realesrgan/executor.py
@@ -9,6 +9,7 @@ from urllib.request import urlopen
 
 import numpy as np
 import torch
+import cv2
 
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
@@ -302,6 +303,7 @@ class RealESRGANUpscaler(Executor):
         for doc in docs:
             img = self.document_to_pil(doc)
             img_arr = np.asarray(img)
+            img_arr = cv2.cvtColor(img_arr, cv2.COLOR_RGB2BGR)
 
             model_dict = resrgan_models.get(model_name, None)
             if model_dict is None:
@@ -317,6 +319,7 @@ class RealESRGANUpscaler(Executor):
                 )
             else:
                 output, _ = upsampler.enhance(img_arr, model_dict["netscale"])
+            output = cv2.cvtColor(output, cv2.COLOR_BGR2RGB)
             image_big = Image.fromarray(output)
 
             buffered = BytesIO()

--- a/executors/realesrgan/executor.py
+++ b/executors/realesrgan/executor.py
@@ -19,9 +19,9 @@ from realesrgan import RealESRGANer
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 
 
-GFPGAN_MODEL_NAME = "GFPGANv1.3.pth"
+GFPGAN_MODEL_NAME = "GFPGANv1.4.pth"
 GFPGAN_MODEL_URL = (
-    "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth"
+    "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth"
 )
 
 

--- a/executors/realesrgan/requirements.txt
+++ b/executors/realesrgan/requirements.txt
@@ -7,6 +7,5 @@ basicsr>=1.4.2
 facexlib>=0.2.5
 gfpgan>=1.3.5
 numpy
-opencv-python
 Pillow
 tqdm


### PR DESCRIPTION
The JINA executor use PIL to load input image which the color space is RGB. While [official GFPGAN/Real-ESRGAN use cv2 to load image which default color space is BGR.](https://github.com/xinntao/Real-ESRGAN/blob/5ca1078535923d485892caee7d7804380bfc87fd/inference_realesrgan.py#L137)

This will cause upscaled image color looks sightly different from original and usually the face becomes pale. For example:

| Original Image  | RGB Input (Current) | BGR Input (Fixed)
| ------------- | ------------- | ------------- | 
|  ![original](https://user-images.githubusercontent.com/5123601/204747293-ba0b5e22-f61b-45ce-bc75-0de2fb1376f4.jpg) |  ![1 3-our-input-RGB](https://user-images.githubusercontent.com/5123601/204747764-b22fc429-f3b9-4814-b585-79cb21144f1b.jpg) |  ![1 3-input-BGR](https://user-images.githubusercontent.com/5123601/204747536-7de79770-9190-48fd-8109-03aae93173fa.jpg) |

Using `cv2.cvtColor` will convert the color space to match the official implementation.